### PR TITLE
Update dag4 dependency to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@next/font": "^13.2.4",
-    "@stardust-collective/dag4": "^2.1.1-beta",
+    "@stardust-collective/dag4": "^2.2.0",
     "@types/node": "18.14.6",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",


### PR DESCRIPTION
Updates @stardust-collective/dag4 dependency to version 2.2.0

This resolves the error below when trying to send transactions using the `yarn metagraph-transaction:send` script
Related to issue #3 

``` 
/usr/local/lib/node_modules/ts-node/src/index.ts:859
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: Unable to compile TypeScript:
scripts/send_transactions/index.ts:199:11 - error TS2345: Argument of type '{ id: string; l0Url: string; l1Url: string; beUrl: string; metagraphId: string; }' is not assignable to parameter of type 'MetagraphNetworkInfo'.
  Object literal may only specify known properties, and 'beUrl' does not exist in type 'MetagraphNetworkInfo'.

199           beUrl: '',
              ~~~~~~~~~
scripts/send_transactions/index.ts:245:11 - error TS2345: Argument of type '{ id: string; l0Url: string; l1Url: string; beUrl: string; metagraphId: string; }' is not assignable to parameter of type 'MetagraphNetworkInfo'.
  Object literal may only specify known properties, and 'beUrl' does not exist in type 'MetagraphNetworkInfo'.

245           beUrl: '',
              ~~~~~~~~~

    at createTSError (/usr/local/lib/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/usr/local/lib/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/usr/local/lib/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/usr/local/lib/node_modules/ts-node/src/index.ts:1433:41)
    at transformSource (/usr/local/lib/node_modules/ts-node/src/esm.ts:400:37)
    at /usr/local/lib/node_modules/ts-node/src/esm.ts:278:53
    at async addShortCircuitFlag (/usr/local/lib/node_modules/ts-node/src/esm.ts:409:15)
    at async nextLoad (node:internal/modules/esm/loader:163:22)
    at async ESMLoader.load (node:internal/modules/esm/loader:605:20)
    at async ESMLoader.moduleProvider (node:internal/modules/esm/loader:457:11) {
  diagnosticCodes: [ 2345, 2345 ]
}
error Command failed with exit code 1.``` 